### PR TITLE
Add native arm64 builds

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -44,11 +44,16 @@ jobs:
 
       - name: Fetch Toolchain
         run: |
-          python3 -m relenv toolchain fetch --arch=${{ matrix.arch }}
+          python3 -m relenv toolchain fetch --arch=${{ matrix.target }}
+
+      - name: Fetch Native Build
+        if: ${{ matrix.arch != matrix.target }}
+        run: |
+          python3 -m relenv fetch
 
       - name: Build
         run: |
-          python3 -m relenv build --arch=${{ matrix.arch }}
+          python3 -m relenv build --arch=${{ matrix.target }}
 
       - name: Verify Build
         run: |
@@ -58,22 +63,22 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.host }}-${{ matrix.arch }}-linux-gnu-logs
+          name: ${{ matrix.host }}-${{ matrix.target }}-linux-gnu-logs
           path: logs/*
           retention-days: 5
 
-      - name: "Upload artifact: build/${{ matrix.host }}-${{ matrix.arch }}-linux-gnu.tar.xz"
+      - name: "Upload artifact: build/${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz"
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.host }}-${{ matrix.arch }}-linux-gnu.tar.xz
-          path: build/${{ matrix.host }}-${{ matrix.arch }}-linux-gnu.tar.xz
+          name: ${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz
+          path: build/${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz
           retention-days: 5
 
       - name: Set Exit Status
         if: always()
         run: |
           mkdir exitstatus
-          echo "${{ job.status }}" > exitstatus/${{ github.job }}-linux-${{ matrix.host }}-${{ matrix.arch }}
+          echo "${{ job.status }}" > exitstatus/${{ github.job }}-linux-${{ matrix.host }}-${{ matrix.target }}
 
       - name: Upload Exit Status
         if: always()

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -22,7 +22,7 @@ jobs:
           - x86_64
           - aarch64
 
-    name: "Python Linux ${{ matrix.arch }} on ${{ matrix.host }}"
+    name: "Python Linux ${{ matrix.target }} on ${{ matrix.host }}"
 
     runs-on: ${{ fromJSON('["ubuntu-22.04", "ARM64"]')[matrix.host == 'aarch64'] }}
 
@@ -47,7 +47,7 @@ jobs:
           python3 -m relenv toolchain fetch --arch=${{ matrix.target }}
 
       - name: Fetch Native Build
-        if: ${{ matrix.arch != matrix.target }}
+        if: ${{ matrix.host != matrix.target }}
         run: |
           python3 -m relenv fetch --arch=${{ matrix.target }}
 

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch Native Build
         if: ${{ matrix.arch != matrix.target }}
         run: |
-          python3 -m relenv fetch --arch={{ matrix.target }}
+          python3 -m relenv fetch --arch=${{ matrix.target }}
 
       - name: Build
         run: |

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get install -y build-essential bison python3-all patchelf
-          python3 -m pip install nox --no-cache
+          python3 -m pip install nox
 
       - name: Fetch Toolchain
         run: |
@@ -59,9 +59,9 @@ jobs:
           python3 -m relenv build --arch=${{ matrix.target }}
 
       - name: Verify Build
-        if: ${{ matrix.host != matrix.target }}
+        if: ${{ matrix.host == matrix.target }}
         run: |
-          nox -e tests -- tests/test_verify_build.py
+          python3 -m nox -e tests -- tests/test_verify_build.py
 
       - name: Linux Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -22,7 +22,7 @@ jobs:
           - x86_64
           - aarch64
 
-    name: "Python Linux ${{ matrix.target }} on ${{ matrix.host }}"
+    name: "Python Linux ${{ matrix.arch }} on ${{ matrix.host }}"
 
     runs-on: ${{ fromJSON('["ubuntu-22.04", "ARM64"]')[matrix.host == 'aarch64'] }}
 

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -21,6 +21,9 @@ jobs:
         target:
           - x86_64
           - aarch64
+        exclude:
+          - host: aarch64
+            target: x86_64
 
     name: "Python Linux ${{ matrix.target }} on ${{ matrix.host }}"
 
@@ -40,7 +43,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get install -y build-essential bison python3-all patchelf
-          python3 -m pip install nox
+          python3 -m pip install nox --no-cache
 
       - name: Fetch Toolchain
         run: |
@@ -56,6 +59,7 @@ jobs:
           python3 -m relenv build --arch=${{ matrix.target }}
 
       - name: Verify Build
+        if: ${{ matrix.host != matrix.target }}
         run: |
           nox -e tests -- tests/test_verify_build.py
 

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install build-essential bison python3-all patchelf
+          sudo apt-get install -y build-essential bison python3-all patchelf
           python3 -m pip install nox
 
       - name: Fetch Toolchain

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -15,13 +15,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        host:
+          - x86_64
+          - aarch64
         arch:
           - x86_64
           - aarch64
 
-    name: "Python Linux"
+    name: "Python Linux ${{ matrix.target }} on ${{ matrix.host }}"
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON('["ubuntu-22.04", "ARM64"]')[matrix.host == 'aarch64'] }}
 
     env:
       RELENV_DATA: ${{ github.workspace }}
@@ -43,17 +46,11 @@ jobs:
         run: |
           python3 -m relenv toolchain fetch --arch=${{ matrix.arch }}
 
-      - name: Fetch Native Build
-        if: ${{ matrix.arch == 'aarch64' }}
-        run: |
-          python3 -m relenv fetch
-
       - name: Build
         run: |
           python3 -m relenv build --arch=${{ matrix.arch }}
 
       - name: Verify Build
-        if: ${{ matrix.arch != 'aarch64' }}
         run: |
           nox -e tests -- tests/test_verify_build.py
 
@@ -61,22 +58,22 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ${{ matrix.arch }}-linux-gnu-logs
+          name: ${{ matrix.host }}-${{ matrix.arch }}-linux-gnu-logs
           path: logs/*
           retention-days: 5
 
-      - name: "Upload artifact: build/${{ matrix.arch }}-linux-gnu.tar.xz"
+      - name: "Upload artifact: build/${{ matrix.host }}-${{ matrix.arch }}-linux-gnu.tar.xz"
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.arch }}-linux-gnu.tar.xz
-          path: build/${{ matrix.arch }}-linux-gnu.tar.xz
+          name: ${{ matrix.host }}-${{ matrix.arch }}-linux-gnu.tar.xz
+          path: build/${{ matrix.host }}-${{ matrix.arch }}-linux-gnu.tar.xz
           retention-days: 5
 
       - name: Set Exit Status
         if: always()
         run: |
           mkdir exitstatus
-          echo "${{ job.status }}" > exitstatus/${{ github.job }}-linux-${{ matrix.arch }}
+          echo "${{ job.status }}" > exitstatus/${{ github.job }}-linux-${{ matrix.host }}-${{ matrix.arch }}
 
       - name: Upload Exit Status
         if: always()

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install build-essential bison python3-all
+          sudo apt-get install build-essential bison python3-all patchelf
           python3 -m pip install nox
 
       - name: Fetch Toolchain

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -59,7 +59,6 @@ jobs:
           python3 -m relenv build --arch=${{ matrix.target }}
 
       - name: Verify Build
-        if: ${{ matrix.host == matrix.target }}
         run: |
           python3 -m nox -e tests -- tests/test_verify_build.py
 

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -68,7 +68,7 @@ jobs:
           path: logs/*
           retention-days: 5
 
-      - name: "Upload artifact: build/${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz"
+      - name: "Upload artifact: build/${{ matrix.target }}-linux-gnu.tar.xz"
         uses: actions/upload-artifact@v3
         if: ${{ matrix.host == matrix.target }}
         with:

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -49,6 +49,10 @@ jobs:
         run: |
           python3 -m relenv toolchain fetch --arch=${{ matrix.target }}
 
+      - name: Check toolchain dir
+        run: |
+          ls -R $RELENV_DATA/toolchain
+
       - name: Fetch Native Build
         if: ${{ matrix.host != matrix.target }}
         run: |

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -18,7 +18,7 @@ jobs:
         host:
           - x86_64
           - aarch64
-        arch:
+        target:
           - x86_64
           - aarch64
 
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch Native Build
         if: ${{ matrix.arch != matrix.target }}
         run: |
-          python3 -m relenv fetch
+          python3 -m relenv fetch --arch={{ matrix.target }}
 
       - name: Build
         run: |

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -56,7 +56,7 @@ jobs:
           python3 -m relenv build --arch=${{ matrix.target }}
 
       - name: Verify Build
-        if: ${{ matrix.host != matrix.target }}
+        if: ${{ matrix.host == matrix.target }}
         run: |
           python3 -m nox -e tests -- tests/test_verify_build.py
 

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -21,9 +21,6 @@ jobs:
         target:
           - x86_64
           - aarch64
-        exclude:
-          - host: aarch64
-            target: x86_64
 
     name: "Python Linux ${{ matrix.target }} on ${{ matrix.host }}"
 
@@ -75,8 +72,8 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ matrix.host == matrix.target }}
         with:
-          name: ${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz
-          path: build/${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz
+          name: ${{ matrix.target }}-linux-gnu.tar.xz
+          path: build/${{ matrix.target }}-linux-gnu.tar.xz
           retention-days: 5
 
       - name: Set Exit Status

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -49,10 +49,6 @@ jobs:
         run: |
           python3 -m relenv toolchain fetch --arch=${{ matrix.target }}
 
-      - name: Check toolchain dir
-        run: |
-          ls -R $RELENV_DATA/toolchain
-
       - name: Fetch Native Build
         if: ${{ matrix.host != matrix.target }}
         run: |
@@ -63,6 +59,7 @@ jobs:
           python3 -m relenv build --arch=${{ matrix.target }}
 
       - name: Verify Build
+        if: ${{ matrix.host != matrix.target }}
         run: |
           python3 -m nox -e tests -- tests/test_verify_build.py
 
@@ -76,6 +73,7 @@ jobs:
 
       - name: "Upload artifact: build/${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz"
         uses: actions/upload-artifact@v3
+        if: ${{ matrix.host == matrix.target }}
         with:
           name: ${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz
           path: build/${{ matrix.host }}-${{ matrix.target }}-linux-gnu.tar.xz

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get install build-essential bison
+          sudo apt-get install build-essential bison python3-all
           python3 -m pip install nox
 
       - name: Fetch Toolchain

--- a/relenv/build/__init__.py
+++ b/relenv/build/__init__.py
@@ -5,7 +5,7 @@ The ``relenv build`` command.
 """
 from . import linux, darwin, windows
 
-from ..common import host_arch
+from ..common import build_arch
 
 import sys
 
@@ -33,7 +33,7 @@ def setup_parser(subparsers):
     build_subparser.set_defaults(func=main)
     build_subparser.add_argument(
         "--arch",
-        default=host_arch(),
+        default=build_arch(),
         choices=mod.ARCHES,
         type=str,
         help="The host architecture [default: %(default)s]",

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -173,7 +173,7 @@ def build_default(env, dirs, logfp):
     ]
     if env["RELENV_HOST"].find("linux") > -1:
         cmd += [
-            "--build={}".format(env["RELENV_BUILD_ARCH"]),
+            "--build={}".format(env["RELENV_BUILD"]),
             "--host={}".format(env["RELENV_HOST"]),
         ]
     runcmd(cmd, env=env, stderr=logfp, stdout=logfp)

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -29,6 +29,7 @@ from relenv.common import (
     build_arch,
     work_root,
     work_dirs,
+    get_triplet,
     get_toolchain,
     extract_archive,
     download_url,
@@ -531,15 +532,9 @@ class Builder:
     ):
         self.dirs = work_dirs(root)
         self.build_arch = build_arch()
+        self.build_triplet = get_triplet(self.build_arch)
         self.arch = arch
-
-        if sys.platform == "darwin":
-            self.triplet = "{}-macos".format(self.arch)
-        elif sys.platform == "win32":
-            self.triplet = "{}-win".format(self.arch)
-        else:
-            self.triplet = "{}-linux-gnu".format(self.arch)
-
+        self.triplet = get_triplet(self.arch)
         self.prefix = self.dirs.build / self.triplet
         self.sources = self.dirs.src
         self.downloads = self.dirs.download
@@ -563,19 +558,11 @@ class Builder:
         :type arch: str
         """
         self.arch = arch
-        if sys.platform == "darwin":
-            self.triplet = "{}-macos".format(self.arch)
-            self.prefix = self.dirs.build / "{}-macos".format(self.arch)
-            # XXX Not used for MacOS
-            self.toolchain = None
-        elif sys.platform == "win32":
-            self.triplet = "{}-win".format(self.arch)
-            self.prefix = self.dirs.build / "{}-win".format(self.arch)
-            # XXX Not used for Windows
+        self.triplet = get_triplet(self.arch)
+        self.prefix = self.dirs.build / self.triplet
+        if sys.platform in ["darwin", "win32"]:
             self.toolchain = None
         else:
-            self.triplet = "{}-linux-gnu".format(self.arch)
-            self.prefix = self.dirs.build / self.triplet
             self.toolchain = get_toolchain(self.arch, self.dirs.root)
 
     @property
@@ -659,6 +646,7 @@ class Builder:
 
         env["RELENV_HOST"] = self.triplet
         env["RELENV_HOST_ARCH"] = self.arch
+        env["RELENV_BUILD"] = self.build_triplet
         env["RELENV_BUILD_ARCH"] = self.build_arch
         if self.build_arch != self.arch:
             native_root = DATA_DIR / "native"

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -899,8 +899,6 @@ class Builder:
             self.clean()
 
         if self.host_arch != self.arch:
-            print(self.host_arch)
-            print(self.arch)
             native_root = DATA_DIR / "native"
             if not native_root.exists():
                 create("native", DATA_DIR)
@@ -1066,7 +1064,7 @@ def finalize(env, dirs, logfp):
         python = dirs.prefix / "bin" / "python3"
         pip = dirs.prefix / "bin" / "pip3"
         if sys.platform == "linux":
-            if env["RELENV_ARCH"] != "x86_64":
+            if env["RELENV_ARCH"] != env["RELENV_HOST_ARCH"]:
                 target = dirs.prefix / "lib" / "python3.10" / "site-packages"
                 python = env["RELENV_NATIVE_PY"]
                 # pip = pathlib.Path(env["RELENV_NATIVE_PY"]).parent / "pip3"

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -827,16 +827,19 @@ class Builder:
         if fails:
             sys.stderr.write("The following failures were reported\n")
             for fail in fails:
-                with io.open(self.dirs.logs / f"{fail}.log") as fp:
-                    fp.seek(0, 2)
-                    end = fp.tell()
-                    ind = end - 4096
-                    if ind > 0:
-                        fp.seek(ind)
-                    else:
-                        fp.seek(0)
-                    sys.stderr.write("=" * 20 + f" {fail} " + "=" * 20 + "\n")
-                    sys.stderr.write(fp.read() + "\n\n")
+                try:
+                    with io.open(self.dirs.logs / f"{fail}.log") as fp:
+                        fp.seek(0, 2)
+                        end = fp.tell()
+                        ind = end - 4096
+                        if ind > 0:
+                            fp.seek(ind)
+                        else:
+                            fp.seek(0)
+                        sys.stderr.write("=" * 20 + f" {fail} " + "=" * 20 + "\n")
+                        sys.stderr.write(fp.read() + "\n\n")
+                except FileNotFoundError:
+                    pass
             sys.stderr.flush()
             if cleanup:
                 self.cleanup()

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -1046,18 +1046,15 @@ def finalize(env, dirs, logfp):
 
     def runpip(pkg, upgrade=False):
         target = None
-        # XXX This needs to be more robust
         python = dirs.prefix / "bin" / "python3"
-        pip = dirs.prefix / "bin" / "pip3"
         if sys.platform == "linux":
             if env["RELENV_HOST_ARCH"] != env["RELENV_BUILD_ARCH"]:
                 target = dirs.prefix / "lib" / "python3.10" / "site-packages"
                 python = env["RELENV_NATIVE_PY"]
-                # pip = pathlib.Path(env["RELENV_NATIVE_PY"]).parent / "pip3"
-                # pip = dirs.prefix / "bin" / "pip3"
         cmd = [
             str(python),
-            str(pip),
+            "-m",
+            "pip",
             "install",
             str(pkg),
         ]

--- a/relenv/build/linux.py
+++ b/relenv/build/linux.py
@@ -124,7 +124,7 @@ def build_gdbm(env, dirs, logfp):
             "./configure",
             "--prefix={}".format(dirs.prefix),
             "--enable-libgdbm-compat",
-            "--build={}".format(env["RELENV_BUILD_ARCH"]),
+            "--build={}".format(env["RELENV_BUILD"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -147,7 +147,7 @@ def build_ncurses(env, dirs, logfp):
     :type logfp: file
     """
     configure = pathlib.Path(dirs.source) / "configure"
-    if env["RELENV_BUILD_ARCH"] != env["RELENV_HOST_ARCH"]:
+    if env["RELENV_BUILD_ARCH"] == "aarch64":
         os.chdir(dirs.tmpbuild)
         runcmd([str(configure)], stderr=logfp, stdout=logfp)
         runcmd(["make", "-C", "include"], stderr=logfp, stdout=logfp)
@@ -164,7 +164,7 @@ def build_ncurses(env, dirs, logfp):
             "--enable-widec",
             "--without-normal",
             "--disable-stripping",
-            "--build={}".format(env["RELENV_BUILD_ARCH"]),
+            "--build={}".format(env["RELENV_BUILD"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -201,7 +201,7 @@ def build_libffi(env, dirs, logfp):
             "./configure",
             "--prefix={}".format(dirs.prefix),
             "--disable-multi-os-directory",
-            "--build={}".format(env["RELENV_BUILD_ARCH"]),
+            "--build={}".format(env["RELENV_BUILD"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -266,7 +266,7 @@ def build_krb(env, dirs, logfp):
             "--prefix={}".format(dirs.prefix),
             "--without-system-verto",
             "--without-libedit",
-            "--build={}".format(env["RELENV_BUILD_ARCH"]),
+            "--build={}".format(env["RELENV_BUILD"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -321,7 +321,7 @@ def build_python(env, dirs, logfp):
         "--with-openssl={}".format(dirs.prefix),
         "--enable-optimizations",
         "--with-ensurepip=no",
-        "--build={}".format(env["RELENV_BUILD_ARCH"]),
+        "--build={}".format(env["RELENV_BUILD"]),
         "--host={}".format(env["RELENV_HOST"]),
     ]
 

--- a/relenv/build/linux.py
+++ b/relenv/build/linux.py
@@ -60,7 +60,7 @@ def populate_env(env, dirs):
     ]
     env["CPPFLAGS"] = " ".join(cpplags).format(prefix=dirs.prefix)
     env["CXXFLAGS"] = " ".join(cpplags).format(prefix=dirs.prefix)
-    if env["RELENV_ARCH"] == "aarch64":
+    if env["RELENV_BUILD_ARCH"] != env["RELENV_HOST_ARCH"]:
         env["LDFLAGS"] = "-Wl,--no-apply-dynamic-relocs {}".format(env["LDFLAGS"])
 
 
@@ -124,7 +124,7 @@ def build_gdbm(env, dirs, logfp):
             "./configure",
             "--prefix={}".format(dirs.prefix),
             "--enable-libgdbm-compat",
-            "--build=x86_64-linux-gnu",
+            "--build={}".format(env["RELENV_BUILD_ARCH"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -147,7 +147,7 @@ def build_ncurses(env, dirs, logfp):
     :type logfp: file
     """
     configure = pathlib.Path(dirs.source) / "configure"
-    if env["RELENV_ARCH"] == "aarch64":
+    if env["RELENV_BUILD_ARCH"] != env["RELENV_HOST_ARCH"]:
         os.chdir(dirs.tmpbuild)
         runcmd([str(configure)], stderr=logfp, stdout=logfp)
         runcmd(["make", "-C", "include"], stderr=logfp, stdout=logfp)
@@ -164,7 +164,7 @@ def build_ncurses(env, dirs, logfp):
             "--enable-widec",
             "--without-normal",
             "--disable-stripping",
-            "--build=x86_64-linux-gnu",
+            "--build={}".format(env["RELENV_BUILD_ARCH"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -201,7 +201,7 @@ def build_libffi(env, dirs, logfp):
             "./configure",
             "--prefix={}".format(dirs.prefix),
             "--disable-multi-os-directory",
-            "--build=x86_64-linux-gnu",
+            "--build={}".format(env["RELENV_BUILD_ARCH"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -234,7 +234,7 @@ def build_zlib(env, dirs, logfp):
             "--prefix={}".format(dirs.prefix),
             "--libdir={}/lib".format(dirs.prefix),
             "--shared",
-            '--archs="-arch {}"'.format(env["RELENV_ARCH"]),
+            '--archs="-arch {}"'.format(env["RELENV_BUILD_ARCH"]),
         ],
         env=env,
         stderr=logfp,
@@ -255,7 +255,7 @@ def build_krb(env, dirs, logfp):
     :param logfp: A handle for the log file
     :type logfp: file
     """
-    if env["RELENV_ARCH"] == "aarch64":
+    if env["RELENV_BUILD_ARCH"] != env["RELENV_HOST_ARCH"]:
         env["krb5_cv_attr_constructor_destructor"] = "yes,yes"
         env["ac_cv_func_regcomp"] = "yes"
         env["ac_cv_printf_positional"] = "yes"
@@ -266,7 +266,7 @@ def build_krb(env, dirs, logfp):
             "--prefix={}".format(dirs.prefix),
             "--without-system-verto",
             "--without-libedit",
-            "--build=x86_64-linux-gnu",
+            "--build={}".format(env["RELENV_BUILD_ARCH"]),
             "--host={}".format(env["RELENV_HOST"]),
         ],
         env=env,
@@ -321,7 +321,7 @@ def build_python(env, dirs, logfp):
         "--with-openssl={}".format(dirs.prefix),
         "--enable-optimizations",
         "--with-ensurepip=no",
-        "--build={}".format(env["RELENV_ARCH"]),
+        "--build={}".format(env["RELENV_BUILD_ARCH"]),
         "--host={}".format(env["RELENV_HOST"]),
     ]
 
@@ -340,7 +340,7 @@ def build_python(env, dirs, logfp):
 
     # RELENVCROSS=relenv/_build/aarch64-linux-gnu  relenv/_build/x86_64-linux-gnu/bin/python3 -m ensurepip
     # python = dirs.prefix / "bin" / "python3"
-    # if env["RELENV_ARCH"] == "aarch64":
+    # if env["RELENV_BUILD_ARCH"] == "aarch64":
     #    python = env["RELENV_NATIVE_PY"]
     # env["PYTHONUSERBASE"] = dirs.prefix
     # runcmd([str(python), "-m", "ensurepip", "-U"], env=env, stderr=logfp, stdout=logfp)

--- a/relenv/build/linux.py
+++ b/relenv/build/linux.py
@@ -60,8 +60,6 @@ def populate_env(env, dirs):
     ]
     env["CPPFLAGS"] = " ".join(cpplags).format(prefix=dirs.prefix)
     env["CXXFLAGS"] = " ".join(cpplags).format(prefix=dirs.prefix)
-    if env["RELENV_BUILD_ARCH"] != env["RELENV_HOST_ARCH"]:
-        env["LDFLAGS"] = "-Wl,--no-apply-dynamic-relocs {}".format(env["LDFLAGS"])
 
 
 def build_bzip2(env, dirs, logfp):
@@ -147,7 +145,7 @@ def build_ncurses(env, dirs, logfp):
     :type logfp: file
     """
     configure = pathlib.Path(dirs.source) / "configure"
-    if env["RELENV_BUILD_ARCH"] == "aarch64":
+    if env["RELENV_HOST_ARCH"] == "aarch64":
         os.chdir(dirs.tmpbuild)
         runcmd([str(configure)], stderr=logfp, stdout=logfp)
         runcmd(["make", "-C", "include"], stderr=logfp, stdout=logfp)

--- a/relenv/build/linux.py
+++ b/relenv/build/linux.py
@@ -145,7 +145,7 @@ def build_ncurses(env, dirs, logfp):
     :type logfp: file
     """
     configure = pathlib.Path(dirs.source) / "configure"
-    if env["RELENV_HOST_ARCH"] == "aarch64":
+    if env["RELENV_BUILD_ARCH"] == "aarch64" or env["RELENV_HOST_ARCH"] == "aarch64":
         os.chdir(dirs.tmpbuild)
         runcmd([str(configure)], stderr=logfp, stdout=logfp)
         runcmd(["make", "-C", "include"], stderr=logfp, stdout=logfp)

--- a/relenv/build/windows.py
+++ b/relenv/build/windows.py
@@ -43,7 +43,7 @@ def build_python(env, dirs, logfp):
         "x86": "win32",
         "arm64": "arm64",
     }
-    arch = env["RELENV_ARCH"]
+    arch = env["RELENV_HOST_ARCH"]
     plat = arch_to_plat[arch]
     cmd = [
         str(dirs.source / "PCbuild" / "build.bat"),

--- a/relenv/common.py
+++ b/relenv/common.py
@@ -53,7 +53,7 @@ class RelenvException(Exception):
     """
 
 
-def host_arch():
+def build_arch():
     machine = platform.machine()
     return machine.lower()
 
@@ -194,7 +194,7 @@ def get_triplet(machine=None, plat=None):
     if not plat:
         plat = sys.platform
     if not machine:
-        machine = host_arch()
+        machine = build_arch()
     if plat == "darwin":
         return f"{machine}-macos"
     elif plat == "win32":

--- a/relenv/create.py
+++ b/relenv/create.py
@@ -10,7 +10,7 @@ import pathlib
 import sys
 import tarfile
 
-from .common import MODULE_DIR, RelenvException, arches, archived_build, host_arch
+from .common import MODULE_DIR, RelenvException, arches, archived_build, build_arch
 
 
 @contextlib.contextmanager
@@ -51,7 +51,7 @@ def setup_parser(subparsers):
     create_subparser.add_argument("name", help="The name of the directory to create")
     create_subparser.add_argument(
         "--arch",
-        default=host_arch(),
+        default=build_arch(),
         choices=arches[sys.platform],
         type=str,
         help="The host architecture [default: %(default)s]",
@@ -72,7 +72,7 @@ def create(name, dest=None, arch=None):
     :raises CreateException: If there is a problem in creating the relenv environment
     """
     if arch is None:
-        arch = host_arch()
+        arch = build_arch()
     if dest:
         writeto = pathlib.Path(dest) / name
     else:

--- a/relenv/fetch.py
+++ b/relenv/fetch.py
@@ -10,10 +10,10 @@ import sys
 from .common import (
     DATA_DIR,
     arches,
+    build_arch,
     download_url,
     extract_archive,
     get_triplet,
-    host_arch,
     work_dir,
 )
 
@@ -29,7 +29,7 @@ def setup_parser(subparsers):
     subparser.set_defaults(func=main)
     subparser.add_argument(
         "--arch",
-        default=host_arch(),
+        default=build_arch(),
         choices=arches[sys.platform],
         help="Architecture to download. [default: %(default)s]",
     )


### PR DESCRIPTION
Fixes: https://github.com/saltstack/relative-environment-for-python/issues/31

Many fixes to get cross compilation on non x86_64 build boxes working. Much of the cross compilation stuff was hard coded and several TODO's needed to be finished. We're not yet running tests against the cross compiled builds but this gets us further along.