### PR TITLE
Fix RELENV_PIP_DIR for python < 3.10

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -183,6 +183,7 @@ jobs:
           python -m relenv build --arch=${{ matrix.arch }}
 
       - name: Verify Build
+        if: ${{ matrix.arch == 'amd64' }}
         run: |
           nox -e tests -- tests/test_verify_build.py
 

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -1053,7 +1053,7 @@ def finalize(env, dirs, logfp):
     # XXX Is fixing shebangs still needed?
     # Fix the shebangs in python's scripts.
     bindir = pathlib.Path(dirs.prefix) / "bin"
-    pyex = bindir / "python3"
+    pyex = bindir / "python3.10"
     shebang = "#!{}".format(str(pyex))
     for root, _dirs, files in os.walk(str(bindir)):
         # print(root), print(dirs), print(files)

--- a/relenv/build/common.py
+++ b/relenv/build/common.py
@@ -959,7 +959,7 @@ def install_sysdata(mod, destfile, buildroot, toolchain):
         if isinstance(val, str):
             for _ in (fbuildroot, ftoolchain):
                 val = _(val)
-                print(f"SYSCONFIG {mod.build_time_vars[key]} => {val}")
+                print(f"SYSCONFIG [{key}] {mod.build_time_vars[key]} => {val}")
         data[key] = val
 
     with open(destfile, "w", encoding="utf8") as f:
@@ -985,7 +985,16 @@ def finalize(env, dirs, logfp):
     # Run relok8 to make sure the rpaths are relocatable.
     relocate_main(dirs.prefix)
     # Install relenv-sysconfigdata module
-    pymodules = pathlib.Path(dirs.prefix) / "lib" / "python3.10"
+    libdir = pathlib.Path(dirs.prefix) / "lib"
+
+    def find_pythonlib(libdir):
+        for root, dirs, files in os.walk(libdir):
+            for _ in dirs:
+                if _.startswith("python"):
+                    return _
+
+
+    pymodules = libdir / find_pythonlib(libdir)
 
     def find_sysconfigdata(pymodules):
         for root, dirs, files in os.walk(pymodules):
@@ -1008,13 +1017,13 @@ def finalize(env, dirs, logfp):
     # Lay down site customize
     bindir = pathlib.Path(dirs.prefix) / "bin"
     sitecustomize = (
-        bindir.parent / "lib" / "python3.10" / "site-packages" / "sitecustomize.py"
+        pymodules / "site-packages" / "sitecustomize.py"
     )
     with io.open(str(sitecustomize), "w") as fp:
         fp.write(SITECUSTOMIZE)
 
     # Lay down relenv.runtime, we'll pip install the rest later
-    relenv = bindir.parent / "lib" / "python3.10" / "site-packages" / "relenv"
+    relenv = pymodules / "site-packages" / "relenv"
     os.makedirs(relenv, exist_ok=True)
     runtime = MODULE_DIR / "runtime.py"
     dest = relenv / "runtime.py"
@@ -1044,7 +1053,7 @@ def finalize(env, dirs, logfp):
     # XXX Is fixing shebangs still needed?
     # Fix the shebangs in python's scripts.
     bindir = pathlib.Path(dirs.prefix) / "bin"
-    pyex = bindir / "python3.10"
+    pyex = bindir / "python3"
     shebang = "#!{}".format(str(pyex))
     for root, _dirs, files in os.walk(str(bindir)):
         # print(root), print(dirs), print(files)
@@ -1075,7 +1084,7 @@ def finalize(env, dirs, logfp):
         python = dirs.prefix / "bin" / "python3"
         if sys.platform == "linux":
             if env["RELENV_HOST_ARCH"] != env["RELENV_BUILD_ARCH"]:
-                target = dirs.prefix / "lib" / "python3.10" / "site-packages"
+                target = pymodules / "site-packages"
                 python = env["RELENV_NATIVE_PY"]
         cmd = [
             str(python),
@@ -1100,8 +1109,8 @@ def finalize(env, dirs, logfp):
     globs = [
         "/bin/python*",
         "/bin/pip*",
-        "/lib/python3.10/ensurepip/*",
-        "/lib/python3.10/site-packages/*",
+        "/lib/python*/ensurepip/*",
+        "/lib/python*/site-packages/*",
         "/include/*",
         "*.so",
         "/lib/*.so.*",

--- a/relenv/common.py
+++ b/relenv/common.py
@@ -14,7 +14,7 @@ import urllib.error
 import urllib.request
 
 # relenv package version
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 MODULE_DIR = pathlib.Path(__file__).resolve().parent
 

--- a/relenv/runtime.py
+++ b/relenv/runtime.py
@@ -214,11 +214,6 @@ def bootstrap():
     """
     Bootstrap the relenv environment.
     """
-    # XXX This was needed for python3.8, meaning the get_paths hack above
-    # doesn't work??
-    if "RELENV_PIP_DIR" in os.environ:
-        sys.prefix = str(root())
-        sys.exec_prefix = str(root())
     cross = os.environ.get("RELENV_CROSS", "")
     if cross:
         crossroot = pathlib.Path(cross).resolve()

--- a/relenv/runtime.py
+++ b/relenv/runtime.py
@@ -144,6 +144,7 @@ class RelenvImporter:
             debug(f"RelenvImporter - load_module {name}")
             mod = importlib.import_module("sysconfig")
             mod.get_config_var = get_config_var_wrapper(mod.get_config_var)
+            mod._PIP_USE_SYSCONFIG = True
             try:
                 # Python >= 3.10
                 scheme = mod.get_default_scheme()

--- a/tests/test_verify_build.py
+++ b/tests/test_verify_build.py
@@ -166,6 +166,7 @@ def test_pip_install_salt_pip_dir(pipexec, build):
     for root, dirs, files in os.walk(build):
         for file in files:
             print(file)
+        break
     for _ in names:
         script = pathlib.Path(build) / _
         assert script.exists()

--- a/tests/test_verify_build.py
+++ b/tests/test_verify_build.py
@@ -163,6 +163,9 @@ def test_pip_install_salt_pip_dir(pipexec, build):
     if sys.platform == "win32":
         names = ["salt-call.exe", "salt-minion.exe"]
 
+    for root, dirs, files in os.walk(build):
+        for file in files:
+            print(file)
     for _ in names:
         script = pathlib.Path(build) / _
         assert script.exists()

--- a/tests/test_verify_build.py
+++ b/tests/test_verify_build.py
@@ -148,7 +148,6 @@ def test_pip_install_idem(pipexec):
         assert p.returncode == 0, f"Failed to pip install {name}"
 
 
-@pytest.mark.skip_on_windows
 def test_pip_install_salt_pip_dir(pipexec, build):
     packages = [
         "salt",

--- a/tests/test_verify_build.py
+++ b/tests/test_verify_build.py
@@ -163,10 +163,6 @@ def test_pip_install_salt_pip_dir(pipexec, build):
     if sys.platform == "win32":
         names = ["salt-call.exe", "salt-minion.exe"]
 
-    for root, dirs, files in os.walk(build):
-        for file in files:
-            print(file)
-        break
     for _ in names:
         script = pathlib.Path(build) / _
         assert script.exists()


### PR DESCRIPTION
Fixes: #38

Forcing `sysconfig._PIP_USE_SYSCONFIG == True`. This forces pip to use sysconfig for scripts location and other installation scheme info rather than relying on distutils. This means python < 3.10 will work the same as modern pythons and fixes the `RELENV_PIP_DIR` environment variable for our current windows builds.