### PR TITLE
Don't default to `latest`.

### DIFF
--- a/relenv/build/__init__.py
+++ b/relenv/build/__init__.py
@@ -136,6 +136,8 @@ def main(args):
         sys.exit()
 
     build.set_arch(args.arch)
+    if build.build_arch != build.arch:
+        print("Warning: Cross compilation support is experimental and is not fully tested or working!")
     steps = None
     if args.steps:
         steps = [_.strip() for _ in args.steps]

--- a/relenv/create.py
+++ b/relenv/create.py
@@ -131,6 +131,8 @@ def main(args):
     :type args: argparse.Namespace
     """
     name = args.name
+    if args.arch != build_arch():
+        print("Warning: Cross compilation support is experimental and is not fully tested or working!")
     try:
         create(name, arch=args.arch, version=args.python)
     except CreateException as exc:

--- a/relenv/fetch.py
+++ b/relenv/fetch.py
@@ -7,7 +7,14 @@ The ``relenv fetch`` command.
 import os
 
 from .build import platform_module, platform_versions
-from .common import DATA_DIR, build_arch, download_url, get_triplet, work_dir
+from .common import (
+    DATA_DIR,
+    __version__,
+    build_arch,
+    download_url,
+    get_triplet,
+    work_dir,
+)
 
 
 def setup_parser(subparsers):
@@ -43,7 +50,7 @@ def main(args):
     :param args: The args passed to the command
     :type args: argparse.Namespace
     """
-    version = os.environ.get("RELENV_FETCH_VERSION", "latest")
+    version = os.environ.get("RELENV_FETCH_VERSION", __version__)
     triplet = get_triplet(machine=args.arch)
     url = f"https://woz.io/relenv/{version}/build/{args.python}-{triplet}.tar.xz"
     builddir = work_dir("build", DATA_DIR)

--- a/relenv/toolchain.py
+++ b/relenv/toolchain.py
@@ -164,7 +164,7 @@ def main(args):
     :param args: The arguments for the command
     :type args: ``argparse.Namespace``
     """
-    version = os.environ.get("RELENV_FETCH_VERSION", "latest")
+    version = os.environ.get("RELENV_FETCH_VERSION", __version__)
     machine = platform.machine()
     dirs = work_dirs()
     print(f"Toolchain directory: {dirs.toolchain}")


### PR DESCRIPTION
The installed relenv is 0.6.0 and 0.7.0 is out.

```
python3 -m relenv fetch --arch=x86_64 --python=3.10.9
Unable to download: https://woz.io/relenv/latest/build/3.10.9-x86_64-linux-gnu.tar.xz HTTP Error 404: Not Found
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/relenv/__main__.py", line 57, in <module>
    main()
  File "/home/ubuntu/.local/lib/python3.10/site-packages/relenv/__main__.py", line 50, in main
    args.func(args)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/relenv/fetch.py", line 51, in main
    download_url(url, builddir)
  File "/home/ubuntu/.local/lib/python3.10/site-packages/relenv/common.py", line 327, in download_url
    fin = urllib.request.urlopen(url)
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.10/urllib/request.py", line 525, in open
    response = meth(req, response)
  File "/usr/lib/python3.10/urllib/request.py", line 634, in http_response
    response = self.parent.error(
  File "/usr/lib/python3.10/urllib/request.py", line 563, in error
    return self._call_chain(*args)
Downloading https://woz.io/relenv/latest/build/3.10.9-x86_64-linux-gnu.tar.xz -> /opt/actions-runner/_work/salt/salt/.relenv/build/3.10.9-x86_64-linux-gnu.tar.xz
  File "/usr/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
Error: Process completed with exit code 1.
```