### PR TITLE
Fixes #116

### DIFF
--- a/relenv/create.py
+++ b/relenv/create.py
@@ -47,7 +47,7 @@ def setup_parser(subparsers):
         "create",
         description=(
             "Create a Relenv environment. This will create a directory of the given "
-            "name with newly created Relenv environment.",
+            "name with newly created Relenv environment."
         ),
     )
     subparser.set_defaults(func=main)


### PR DESCRIPTION
Fixes #116 (`relenv create --help` throws an error)

A multi-line string wrapped in parentheses _without_ commas is considered a string in Python.

A multi-line string wrapped in parentheses _with_ commas is considered a Tuple (of strings).

Probably just a typo :) 