### PR TITLE
Fix issue with hashilb not finding openssl modules

### DIFF
--- a/relenv/common.py
+++ b/relenv/common.py
@@ -13,7 +13,6 @@ import tarfile
 import textwrap
 import time
 import urllib.error
-import urllib.request
 
 # relenv package version
 __version__ = "0.13.3"
@@ -335,6 +334,9 @@ def check_url(url, timeout=30):
     """
     Check that the url returns a 200.
     """
+    # Late import so we do not import hashlib before runtime.bootstrap is called.
+    import urllib.request
+
     fin = None
     try:
         fin = urllib.request.urlopen(url, timeout=timeout)
@@ -352,6 +354,9 @@ def fetch_url(url, fp, backoff=3, timeout=30):
 
     This method will store the contents in the given file like object.
     """
+    # Late import so we do not import hashlib before runtime.bootstrap is called.
+    import urllib.request
+
     if backoff < 1:
         backoff = 1
     n = 0

--- a/relenv/runtime.py
+++ b/relenv/runtime.py
@@ -754,6 +754,8 @@ def setup_openssl():
     """
     Configure openssl certificate locations.
     """
+    if "OPENSSL_MODULES" not in os.environ and sys.platform != "win32":
+        os.environ["OPENSSL_MODULES"] = str(sys.RELENV / "lib" / "ossl-modules")
     # Use system openssl dirs
     # XXX Should we also setup SSL_CERT_FILE, OPENSSL_CONF &
     # OPENSSL_CONF_INCLUDE?
@@ -775,15 +777,17 @@ def setup_openssl():
                     msg += f": {proc.stderr}"
                 debug(msg)
             else:
-                _, directory = proc.stdout.split(":")
+                try:
+                    _, directory = proc.stdout.split(":")
+                except ValueError:
+                    debug(f"Unable to parse openssldir")
+                    return
                 path = pathlib.Path(directory.strip().strip('"'))
                 if not os.environ.get("SSL_CERT_DIR"):
                     os.environ["SSL_CERT_DIR"] = str(path / "certs")
                 cert_file = path / "cert.pem"
                 if cert_file.exists() and not os.environ.get("SSL_CERT_FILE"):
                     os.environ["SSL_CERT_FILE"] = str(cert_file)
-        if "OPENSSL_MODULES" not in os.environ:
-            os.environ["OPENSSL_MODULES"] = str(sys.RELENV / "lib" / "ossl-modules")
 
 
 def setup_crossroot():


### PR DESCRIPTION
Makes sure we do not import hashlib before running relenv.runtime.bootstrap so that hashilb will automatically find the relenv openssl modules directory.

FIxes #139